### PR TITLE
Ajuste na query SqlAlchemy e serializer com chaves repetidas

### DIFF
--- a/backend/flask-api/src/apis/complemento_api.py
+++ b/backend/flask-api/src/apis/complemento_api.py
@@ -1,17 +1,17 @@
 from flask import request, Response
 from flask_restful import Resource,reqparse, abort
-from ..servicos import movimento_servico
+from ..servicos import complemento_servico
 from ..utils import helper
 import json
 import traceback
 
 
-class MovimentoAPI(Resource):
+class ComplementoAPI(Resource):
 
     def get(self):
         try:
             retorno = [helper.serializar(evento)
-                       for evento in movimento_servico.listar_movimentos()]
+                       for evento in complemento_servico.listar_complementos()]
             return Response(json.dumps(retorno), status=200)
         except Exception as e:
             traceback.print_exc()
@@ -21,8 +21,8 @@ class MovimentoAPI(Resource):
         try:
             body = json.loads(request.get_data().decode('UTF-8'))
             if body:
-                id_movimento = movimento_servico.incluir_movimento(body)
-                return Response(json.dumps({"id_movimento": id_movimento}), status=201)
+                id_complemento = complemento_servico.incluir_complemento(body)
+                return Response(json.dumps({"id_complemento": id_complemento}), status=201)
         except Exception as e:
             traceback.print_exc()
             return Response('error: \'{0}\''.format(''.join(e.args)), status=500, mimetype='application/json')
@@ -31,7 +31,7 @@ class MovimentoAPI(Resource):
         try:
             body = json.loads(request.get_data().decode('UTF-8'))
             if body:
-                movimento_servico.remover_movimento(body.get('id_movimento'))
+                complemento_servico.remover_complemento(body.get('id_complemento'))
                 return Response('Registro excluído com sucesso', status=200)
         except Exception as e:
             traceback.print_exc()
@@ -39,16 +39,18 @@ class MovimentoAPI(Resource):
 
 
     def put(self):
-        parser.add_argument('id_movimento', required=True, location='json', type=int,
+        parser.add_argument('id_complemento', required=True, location='json', type=int,
             help="XXXXXXXXXXXXXx")
-        parser.add_argument('cd_tpu_movimento', required=True, location='json', type=str,
+        parser.add_argument('cd_tpu_complemento', required=True, location='json', type=str,
             help="XXXXXXXXXXXXX.")
-        parser.add_argument('id_evento', required=True, location='json', type=int,
+        parser.add_argument('vl_complemento', required=True, location='json', type=str,
+            help="XXXXXXXXXXXXXXXXX")
+        parser.add_argument('id_movimento', required=True, location='json', type=int,
             help="XXXXXXXXXXXXXXXXX")
 
         args = parser.parse_args()
 
-        return movimento_servico.atualizar_movimento(args)
+        return complemento_servico.atualizar_complemento(args)
 
 
 
@@ -57,4 +59,4 @@ class MovimentoAPI(Resource):
 
 def configure_api(api):
     api.add_resource(
-        MovimentoAPI, '/api/v1.0/movimento')
+        ComplementoAPI, '/api/v1.0/complemento')

--- a/backend/flask-api/src/apis/evento_api.py
+++ b/backend/flask-api/src/apis/evento_api.py
@@ -1,5 +1,5 @@
 from flask import request, Response
-from flask_restful import Resource
+from flask_restful import Resource,reqparse, abort
 from ..servicos import evento_servico
 from ..servicos import movimento_servico
 from ..utils import helper
@@ -37,7 +37,21 @@ class EventoAPI(Resource):
         except Exception as e:
             traceback.print_exc()
             return Response('error: \'{0}\''.format(''.join(e.args)), status=500, mimetype='application/json')
+    def put(self):
+        parser.add_argument('id_evento', required=True, location='json', type=int,
+            help="XXXXXXXXXXXXXx")
+        parser.add_argument('ds_evento', required=True, location='json', type=str,
+            help="XXXXXXXXXXXXX.")
+        parser.add_argument('cd_evento', required=True, location='json', type=str,
+            help="XXXXXXXXXXXXXXXXX")
+        parser.add_argument('ind_fluxo_ri', required=True, location='json', type=str,
+            help="XXXXXXXXXXXXXXXX")
+        parser.add_argument('ind_tipo_especial', required=False, location='json',type=str,
+            help="XXXXXXXXXXXXXXXX")
 
+        args = parser.parse_args()
+
+        return evento_servico.atualizar_evento(args)
 
 class EventoIdAPI(Resource):
 

--- a/backend/flask-api/src/apis/fluxo_api.py
+++ b/backend/flask-api/src/apis/fluxo_api.py
@@ -1,5 +1,5 @@
 from flask import request, Response
-from flask_restful import Resource
+from flask_restful import Resource,reqparse, abort
 from ..servicos import fluxo_servico
 from ..utils import helper
 import json

--- a/backend/flask-api/src/apis/fluxo_api.py
+++ b/backend/flask-api/src/apis/fluxo_api.py
@@ -37,6 +37,32 @@ class FluxoAPI(Resource):
             traceback.print_exc()
             return Response('error: \'{0}\''.format(''.join(e.args)), status=500, mimetype='application/json')
 
+    def put(self):
+        parser.add_argument('id_fluxo_movimento', required=True, location='json', type=int,
+            help="XXXXXXXXXXXXXx")
+        parser.add_argument('id_situacao_origem', required=True, location='json', type=int,
+            help="XXXXXXXXXXXXX.")
+        parser.add_argument('id_evento', required=True, location='json', type=int,
+            help="XXXXXXXXXXXXXXXXX")
+        parser.add_argument('id_situacao_destino', required=True, location='json', type=int,
+            help="XXXXXXXXXXXXXXXX")
+        parser.add_argument('ind_consistente', required=True, location='json',type=str,
+            help="XXXXXXXXXXXXXXXX")
+        parser.add_argument('ind_efetiva', required=True, location='json',type=str,
+            help="XXXXXXXXXXXXXXXX")
+        parser.add_argument('ind_fluxo_ri', required=True, location='json',type=str,
+            help="XXXXXXXXXXXXXXXX")
+        parser.add_argument('id_grupo', required=True, location='json', type=int,
+            help="XXXXXXXXXXXXXXXX")
+        parser.add_argument('sg_tribunal', required=True, location='json',type=str,
+            help="XXXXXXXXXXXXXXXX")
+        parser.add_argument('sg_grau', required=False, location='json',type=str,
+            help="XXXXXXXXXXXXXXXX")
+        
+        args = parser.parse_args()
+    
+        return fluxo_servico.atualizar_fluxo(args)
+
 
 class FluxoFiltroAPI(Resource):
 

--- a/backend/flask-api/src/apis/grupo_api.py
+++ b/backend/flask-api/src/apis/grupo_api.py
@@ -38,6 +38,23 @@ class GrupoAPI(Resource):
             traceback.print_exc()
             return Response('error: \'{0}\''.format(''.join(e.args)), status=500, mimetype='application/json')
 
+    def put(self):
+        parser.add_argument('id_grupo', required=True, location='json', type=int,
+            help="XXXXXXXXXXXXXx")
+        parser.add_argument('ds_grupo', required=True, location='json', type=str,
+            help="XXXXXXXXXXXXX.")
+        parser.add_argument('cd_grupo', required=True, location='json', type=str,
+            help="XXXXXXXXXXXXXXXXX")
+        parser.add_argument('sg_tribunal', required=True, location='json', type=str,
+            help="XXXXXXXXXXXXXXXX")
+        parser.add_argument('sg_grau', required=True, location='json',type=str,
+            help="XXXXXXXXXXXXXXXX")
+             
+        args = parser.parse_args()
+        
+        return grupo_servico.atualizar_grupo(args)
+
+
 
 class GrupoIdAPI(Resource):
 

--- a/backend/flask-api/src/apis/movimento_api.py
+++ b/backend/flask-api/src/apis/movimento_api.py
@@ -1,0 +1,60 @@
+from flask import request, Response
+from flask_restful import Resource,reqparse, abort
+from ..servicos import movimento_servico
+from ..utils import helper
+import json
+import traceback
+
+
+class MovimentoAPI(Resource):
+
+    def get(self):
+        try:
+            retorno = [helper.serializar(evento)
+                       for evento in movimento_servico.listar_movimentos()]
+            return Response(json.dumps(retorno), status=200)
+        except Exception as e:
+            traceback.print_exc()
+            return Response('error: \'{0}\''.format(''.join(e.args)), status=500, mimetype='application/json')
+
+    def post(self):
+        try:
+            body = json.loads(request.get_data().decode('UTF-8'))
+            if body:
+                id_movimento = movimento_servico.incluir_movimento(body)
+                return Response(json.dumps({"id_evento": id_movimento}), status=201)
+        except Exception as e:
+            traceback.print_exc()
+            return Response('error: \'{0}\''.format(''.join(e.args)), status=500, mimetype='application/json')
+
+    def delete(self):
+        try:
+            body = json.loads(request.get_data().decode('UTF-8'))
+            if body:
+                movimento_servico.remover_movimento(body.get('id_movimento'))
+                return Response('Registro excluído com sucesso', status=200)
+        except Exception as e:
+            traceback.print_exc()
+            return Response('error: \'{0}\''.format(''.join(e.args)), status=500, mimetype='application/json')
+
+
+    def put(self):
+        parser.add_argument('id_movimento', required=True, location='json', type=int,
+            help="XXXXXXXXXXXXXx")
+        parser.add_argument('cd_tpu_movimento', required=True, location='json', type=str,
+            help="XXXXXXXXXXXXX.")
+        parser.add_argument('id_evento', required=True, location='json', type=int,
+            help="XXXXXXXXXXXXXXXXX")
+
+        args = parser.parse_args()
+
+        return movimento_servico.atualizar_movimento(args)
+
+
+
+
+
+
+def configure_api(api):
+    api.add_resource(
+        MovimentoAPI, '/api/v1.0/movimento')

--- a/backend/flask-api/src/apis/situacao_api.py
+++ b/backend/flask-api/src/apis/situacao_api.py
@@ -1,10 +1,14 @@
 from json import encoder
 from flask import request, Response
-from flask_restful import Resource
+from flask_restful import Resource,reqparse, abort
 from ..servicos import situacao_servico
 from ..utils import helper
+from ..persistencia.database import db
 import json
 import traceback
+
+
+parser = reqparse.RequestParser()
 
 
 class SituacaoAPI(Resource):
@@ -37,6 +41,34 @@ class SituacaoAPI(Resource):
         except Exception as e:
             traceback.print_exc()
             return Response('error: \'{0}\''.format(''.join(e.args)), status=500, mimetype='application/json')
+    
+    def put(self):
+        parser.add_argument('id_situacao', required=True, location='json', type=int,
+            help="XXXXXXXXXXXXXx")
+        parser.add_argument('ds_situacao', required=True, location='json', type=str,
+            help="XXXXXXXXXXXXX.")
+        parser.add_argument('cd_situacao', required=True, location='json', type=str,
+            help="XXXXXXXXXXXXXXXXX")
+        parser.add_argument('ind_principal', required=True, location='json', type=str,
+            help="XXXXXXXXXXXXXXXX")
+        parser.add_argument('ind_ri', required=True, location='json',type=str,
+            help="XXXXXXXXXXXXXXXX")
+        parser.add_argument('sg_tribunal', required=True, location='json',type=str,
+            help="XXXXXXXXXXXXXXXX")
+        parser.add_argument('sg_grau', required=True, location='json',type=str,
+            help="XXXXXXXXXXXXXXXX")
+        parser.add_argument('fl_inicio', required=True, location='json', type=str,
+            help="XXXXXXXXXXXXXXXX")
+        parser.add_argument('fl_fim', required=True, location='json',type=str,
+            help="XXXXXXXXXXXXXXXX")
+        parser.add_argument('id_grupo', required=False, location='json',type=int,
+            help="XXXXXXXXXXXXXXXX")
+        
+        args = parser.parse_args()
+        
+        return situacao_servico.atualizar_situacao(args)
+       
+        
 
 
 class SituacaoFiltroAPI(Resource):

--- a/backend/flask-api/src/apis/situacao_api.py
+++ b/backend/flask-api/src/apis/situacao_api.py
@@ -66,7 +66,9 @@ class SituacaoProcesso(Resource):
 
     def get(self, str_consistente):
         try:
-            retorno = situacao_servico.listar_processos_consistencia(str_consistente)
+            retorno = [helper.serializar_lista(situacao)
+                       for situacao in situacao_servico.listar_processos_consistencia(str_consistente)]
+            
             return Response(json.dumps(retorno, cls=helper.JSONEnconder), status=200)
         except Exception as e:
             traceback.print_exc()
@@ -76,7 +78,9 @@ class FluxoOfProcesso(Resource):
 
     def get(self, id_processo):
         try:
-            retorno = situacao_servico.listar_fluxo_processo(id_processo)
+            retorno = [helper.serializar_lista(situacao)
+                       for situacao in situacao_servico.listar_fluxo_processo(id_processo)]
+
             return Response(json.dumps(retorno, cls=helper.JSONEnconder), status=200)
         except Exception as e:
             traceback.print_exc()

--- a/backend/flask-api/src/servicos/complemento_servico.py
+++ b/backend/flask-api/src/servicos/complemento_servico.py
@@ -1,0 +1,54 @@
+import re
+from ..entidades.modelo_fluxo import Complemento
+from ..persistencia.database import db
+from sqlalchemy.orm import aliased,load_only,Load,exc
+from flask_restful import abort
+from flask import  Response
+import json
+
+
+def incluir_complemento(parametros):
+    complemento = Complemento(**parametros)
+    complemento.id_movimento = None
+    db.session.add(complemento)
+    db.session.commit()
+    return complemento.id_movimento
+
+
+def remover_complemento(id_complemento):
+    db.session.query(Complemento).filter(
+        Complemento.id_movimento == id_complemento).delete()
+    db.session.commit()
+
+
+def listar_complementos():
+    return Complemento.query.all()
+
+
+def listar_complementos_id(id_movimento):
+    return db.session.query(Complemento).filter(Complemento.id_complemento == id_complemento).all()
+
+
+def atualizar_complemento(data_json):
+    
+    try:
+        obj_db = Complemento.query.filter(Complemento.id_complemento == int(data_json['id_complemento'])).one()
+    
+    except (exc.NoResultFound, exc.MultipleResultsFound) as error:
+        return abort(404, message="ERRO: {}".format(error))    
+    
+    else:
+        
+        for key, value in data_json.items():
+            setattr(obj_db, key, value)
+       
+
+        try:        
+            db.session.commit()
+        except Exception as error:
+            db.session.rollback()
+            return abort(404, message="ERRO: {}".format(error))
+        
+                
+        
+        return Response(json.dumps({'message':'Situacao com id {} atualizada.'.format(obj_db.id_complemento)}), status=200)

--- a/backend/flask-api/src/servicos/evento_servico.py
+++ b/backend/flask-api/src/servicos/evento_servico.py
@@ -1,6 +1,10 @@
 import re
 from ..entidades.modelo_fluxo import Evento
 from ..persistencia.database import db
+from sqlalchemy.orm import aliased,load_only,Load,exc
+from flask_restful import abort
+from flask import  Response
+import json
 
 
 def incluir_evento(parametros):
@@ -22,3 +26,28 @@ def listar_eventos():
 
 def listar_eventos_id(id_evento):
     return db.session.query(Evento).filter(Evento.id_evento == id_evento).all()
+
+
+def atualizar_evento(data_json):
+    
+    try:
+        obj_db = Evento.query.filter(Evento.id_evento == int(data_json['id_evento'])).one()
+    
+    except (exc.NoResultFound, exc.MultipleResultsFound) as error:
+        return abort(404, message="ERRO: {}".format(error))    
+    
+    else:
+        
+        for key, value in data_json.items():
+            setattr(obj_db, key, value)
+       
+
+        try:        
+            db.session.commit()
+        except Exception as error:
+            db.session.rollback()
+            return abort(404, message="ERRO: {}".format(error))
+        
+                
+        
+        return Response(json.dumps({'message':'Situacao com id {} atualizada.'.format(obj_db.id_evento)}), status=200)

--- a/backend/flask-api/src/servicos/fluxo_servico.py
+++ b/backend/flask-api/src/servicos/fluxo_servico.py
@@ -165,3 +165,28 @@ def funcao_recursiva(cd_tribunal, cd_instancia, ind_consistente, id_situacao, li
         return {'cd_situacao': linha[0],
                 'ds_situacao': linha[1]
                 }
+
+
+def atualizar_fluxo(data_json):
+    
+    try:
+        obj_db = FluxoMovimentos.query.filter(FluxoMovimentos.id_fluxo_movimento == int(data_json['id_fluxo_movimento'])).one()
+    
+    except (exc.NoResultFound, exc.MultipleResultsFound) as error:
+        return abort(404, message="ERRO: {}".format(error))    
+    
+    else:
+        
+        for key, value in data_json.items():
+            setattr(obj_db, key, value)
+       
+
+        try:        
+            db.session.commit()
+        except Exception as error:
+            db.session.rollback()
+            return abort(404, message="ERRO: {}".format(error))
+        
+                
+        
+        return Response(json.dumps({'message':'Situacao com id {} atualizada.'.format(obj_db.id_fluxo_movimento)}), status=200)

--- a/backend/flask-api/src/servicos/fluxo_servico.py
+++ b/backend/flask-api/src/servicos/fluxo_servico.py
@@ -3,6 +3,10 @@ from typing import Dict
 from ..entidades.modelo_fluxo import FluxoMovimentos
 from ..persistencia.database import db
 import sys
+from sqlalchemy.orm import aliased,load_only,Load,exc
+from flask_restful import abort
+from flask import  Response
+import json
 
 
 def incluir_fluxo(parametros):

--- a/backend/flask-api/src/servicos/grupo_servico.py
+++ b/backend/flask-api/src/servicos/grupo_servico.py
@@ -1,7 +1,9 @@
 import re
 from ..entidades.modelo_fluxo import GrupoSituacao
 from ..persistencia.database import db
-
+from flask_restful import abort
+from flask import  Response
+import json
 
 def incluir_grupo(parametros):
     grupo = GrupoSituacao(**parametros)
@@ -27,3 +29,28 @@ def listar_grupos_id(id_grupo):
 
 def listar_grupos_filtro(cd_tribunal, cd_grau):
     return db.session.query(GrupoSituacao).filter(GrupoSituacao.sg_tribunal == cd_tribunal and GrupoSituacao.sg_grau == cd_grau).all()
+
+
+def atualizar_grupo(data_json):
+    
+    try:
+        db_obj = GrupoSituacao.query.filter(GrupoSituacao.id_grupo == int(data_json['id_grupo'])).one()
+    
+    except (exc.NoResultFound, exc.MultipleResultsFound) as error:
+        return abort(404, message="ERRO: {}".format(error))    
+    
+    else:
+        
+        for key, value in data_json.items():
+            setattr(db_obj, key, value)
+       
+
+        try:        
+            db.session.commit()
+        except Exception as error:
+            db.session.rollback()
+            return abort(404, message="ERRO: {}".format(error))
+        
+                
+        
+        return Response(json.dumps({'message':'Situacao com id {} atualizada.'.format(vars(db_obj))}), status=200)

--- a/backend/flask-api/src/servicos/grupo_servico.py
+++ b/backend/flask-api/src/servicos/grupo_servico.py
@@ -1,6 +1,7 @@
 import re
 from ..entidades.modelo_fluxo import GrupoSituacao
 from ..persistencia.database import db
+from sqlalchemy.orm import aliased,load_only,Load,exc
 from flask_restful import abort
 from flask import  Response
 import json

--- a/backend/flask-api/src/servicos/movimento_servico.py
+++ b/backend/flask-api/src/servicos/movimento_servico.py
@@ -1,6 +1,10 @@
 import re
 from ..entidades.modelo_fluxo import Movimento
 from ..persistencia.database import db
+from sqlalchemy.orm import aliased,load_only,Load,exc
+from flask_restful import abort
+from flask import  Response
+import json
 
 
 def incluir_movimento(parametros):
@@ -27,3 +31,28 @@ def listar_movimentos_evento(id_evento):
 
 def listar_movimentos_id(id_movimento):
     return db.session.query(Movimento).filter(Movimento.id_movimento == id_movimento).all()
+
+
+def atualizar_movimento(data_json):
+    
+    try:
+        obj_db = Movimento.query.filter(Movimento.id_movimento == int(data_json['id_movimento'])).one()
+    
+    except (exc.NoResultFound, exc.MultipleResultsFound) as error:
+        return abort(404, message="ERRO: {}".format(error))    
+    
+    else:
+        
+        for key, value in data_json.items():
+            setattr(obj_db, key, value)
+       
+
+        try:        
+            db.session.commit()
+        except Exception as error:
+            db.session.rollback()
+            return abort(404, message="ERRO: {}".format(error))
+        
+                
+        
+        return Response(json.dumps({'message':'Situacao com id {} atualizada.'.format(obj_db.id_movimento)}), status=200)

--- a/backend/flask-api/src/servicos/situacao_servico.py
+++ b/backend/flask-api/src/servicos/situacao_servico.py
@@ -1,8 +1,10 @@
 import re
 from ..entidades.modelo_fluxo import Situacao, HistoricoSituacao, Evento, Processo
 from ..persistencia.database import db
-from sqlalchemy.orm import aliased,load_only,Load,with_expression
-
+from sqlalchemy.orm import aliased,load_only,Load,exc
+from flask_restful import abort
+from flask import  Response
+import json
 
 def incluir_situacao(parametros):
     situacao = Situacao(**parametros)
@@ -91,3 +93,35 @@ def listar_fluxo_processo(id_processo):
         return cursor
     else:
         return []
+
+
+def atualizar_situacao(data_json):
+    
+    try:
+        situacao = Situacao.query.filter(Situacao.id_situacao == int(data_json['id_situacao'])).one()
+    
+    except (exc.NoResultFound, exc.MultipleResultsFound) as error:
+        return abort(404, message="ERRO: {}".format(error))    
+    
+    else:
+        
+        for key, value in data_json.items():
+            setattr(situacao, key, value)
+       
+
+        try:        
+            db.session.commit()
+        except Exception as error:
+            db.session.rollback()
+            return abort(404, message="ERRO: {}".format(error))
+        
+                
+        
+        return Response(json.dumps({'message':'Situacao com id {} atualizada.'.format(situacao.id_situacao)}), status=200)
+
+   
+   
+    
+
+
+

--- a/backend/flask-api/src/servicos/situacao_servico.py
+++ b/backend/flask-api/src/servicos/situacao_servico.py
@@ -1,7 +1,7 @@
 import re
 from ..entidades.modelo_fluxo import Situacao, HistoricoSituacao, Evento, Processo
 from ..persistencia.database import db
-from sqlalchemy.orm import aliased
+from sqlalchemy.orm import aliased,load_only,Load,with_expression
 
 
 def incluir_situacao(parametros):
@@ -49,25 +49,38 @@ def listar_processos_consistencia(str_consistente):
     SituacaoOrigem = aliased(Situacao)
     SituacaoDestino = aliased(Situacao)
     cursor = db.session.query(HistoricoSituacao, SituacaoOrigem, SituacaoDestino, Evento, Processo).\
-        with_entities(Processo.nu_processo, Processo.cd_classe, Processo.cd_processo, SituacaoOrigem.ds_situacao, Evento.ds_evento, SituacaoDestino.ds_situacao, HistoricoSituacao.dt_ocorrencia, HistoricoSituacao.ind_consistente).\
-        join(SituacaoOrigem, HistoricoSituacao.id_situacao_origem == SituacaoOrigem.id_situacao).\
-        join(SituacaoDestino, HistoricoSituacao.id_situacao_destino == SituacaoDestino.id_situacao).\
-        join(Evento, HistoricoSituacao.id_evento == Evento.id_evento).\
-        join(Processo, HistoricoSituacao.cd_processo == Processo.cd_processo).\
-        filter(HistoricoSituacao.ind_consistente == str_consistente).\
-        order_by(Processo.cd_processo, HistoricoSituacao.dt_ocorrencia).all()
+    options(
+        Load(Processo).load_only("nu_processo", "cd_classe","cd_processo"),
+        Load(SituacaoOrigem).load_only("ds_situacao"),
+        Load(Evento).load_only("ds_evento"),
+        Load(SituacaoDestino).load_only("ds_situacao"),
+        Load(HistoricoSituacao).load_only("dt_ocorrencia","ind_consistente")
+    ).\
+    join(SituacaoOrigem, HistoricoSituacao.id_situacao_origem == SituacaoOrigem.id_situacao).\
+    join(SituacaoDestino, HistoricoSituacao.id_situacao_destino == SituacaoDestino.id_situacao).\
+    join(Evento, HistoricoSituacao.id_evento == Evento.id_evento).\
+    join(Processo, HistoricoSituacao.cd_processo == Processo.cd_processo).\
+    filter(HistoricoSituacao.ind_consistente == str_consistente).\
+    order_by(Processo.cd_processo, HistoricoSituacao.dt_ocorrencia).all()
+
     if cursor is not None:
-        return [construir_processo_fluxo(situacao)
-                for situacao in cursor]
+        return cursor
     else:
-        return {}
+        print('None')
+        return []
 
 
 def listar_fluxo_processo(id_processo):
     SituacaoOrigem = aliased(Situacao)
     SituacaoDestino = aliased(Situacao)
     cursor = db.session.query(HistoricoSituacao, SituacaoOrigem, SituacaoDestino, Evento, Processo).\
-        with_entities(Processo.nu_processo, Processo.cd_classe, Processo.cd_processo, SituacaoOrigem.ds_situacao, Evento.ds_evento, SituacaoDestino.ds_situacao, HistoricoSituacao.dt_ocorrencia, HistoricoSituacao.ind_consistente).\
+        options(
+            Load(Processo).load_only("nu_processo", "cd_classe","cd_processo"),
+            Load(SituacaoOrigem).load_only("ds_situacao"),
+            Load(Evento).load_only("ds_evento"),
+            Load(SituacaoDestino).load_only("ds_situacao"),
+            Load(HistoricoSituacao).load_only("dt_ocorrencia","ind_consistente")
+        ).\
         join(SituacaoOrigem, HistoricoSituacao.id_situacao_origem == SituacaoOrigem.id_situacao).\
         join(SituacaoDestino, HistoricoSituacao.id_situacao_destino == SituacaoDestino.id_situacao).\
         join(Evento, HistoricoSituacao.id_evento == Evento.id_evento).\
@@ -75,7 +88,6 @@ def listar_fluxo_processo(id_processo):
         filter(HistoricoSituacao.cd_processo == id_processo).\
         order_by(HistoricoSituacao.dt_ocorrencia).all()
     if cursor is not None:
-        return [construir_processo_fluxo(situacao)
-                   for situacao in cursor]
+        return cursor
     else:
-        return {}
+        return []

--- a/backend/flask-api/src/utils/helper.py
+++ b/backend/flask-api/src/utils/helper.py
@@ -3,11 +3,33 @@ import json
 import datetime
 import math
 import locale
-
+from collections import Counter
 
 def serializar(obj):
     return {k: v for (k, v) in vars(obj).items()
             if not str(k).startswith('_')}
+
+def serializar_lista(lista_de_tupla):
+    #if len(lista_de_tupla) == 0:
+    #    return {}
+    lista_de_dicionario = [serializar(obj) for obj in lista_de_tupla]
+    
+    #Deal with objects from the same table like Situacao.ds_situacao origem e destino
+    out_dict = {}
+    repeated_key_counter = Counter()    
+    for d in lista_de_dicionario:
+        for k,v in d.items():
+            if out_dict.get(k) is None:
+                out_dict[k] = v
+            else:
+                repeated_key_counter[k]+=1
+                k+='_'+str(repeated_key_counter[k]+1)
+                out_dict[k] = v    
+                  
+
+    return out_dict
+        
+
 
 
 class JSONEnconder(json.JSONEncoder):


### PR DESCRIPTION
Query SQLAlchemy quando utiliza with_entities para selecionar as colunas, retorna tuplas não nomeadas. O que foge do padrão da solução.

A solução é utilizar options com Load para selecionar colunas. Nesse caso as colunas com mesmo nome eram sobrescritas na função serializar. Para solucionar, a função serializar_lista_tuplas enumera as colunas repetidas na ordem da query:

```
        Load(Processo).load_only("nu_processo", "cd_classe","cd_processo"),
        Load(SituacaoOrigem).load_only("ds_situacao"),
        Load(Evento).load_only("ds_evento"),
        Load(SituacaoDestino).load_only("ds_situacao"),
        Load(HistoricoSituacao).load_only("dt_ocorrencia","ind_consistente")
```
No caso acima, ds_situacao e id_situacao eram sobrescritos somente com o ultimo valor. No serializador novo o resultado é o seguinte:
`  {
      "ind_consistente":"S",
      "id_hist_situacao":74059,
      "dt_ocorrencia":"2019-07-22T09:21:26",
      "ds_situacao":"In\u00edcio de fluxo",
      "id_situacao":1,
      "ds_situacao_2":"Pendente de conclus\u00e3o para relatar",
      "id_situacao_2":21,
      "id_evento":35,
      "ds_evento":"Distribui\u00e7\u00e3o para o relator",
      "cd_processo":"TRT3_G2_00000054820105030071_1004",
      "cd_classe":"1004",
      "nu_processo":"00000054820105030071"
   }`

Onde ds_situacao_2 e id_situacao_2 são referentes a Load(SituacaoDestino).load_only("ds_situacao").